### PR TITLE
Fix null check in order query handler

### DIFF
--- a/Application/Features/Orders/Handlers/Queries/GetOrderQueryHandler.cs
+++ b/Application/Features/Orders/Handlers/Queries/GetOrderQueryHandler.cs
@@ -25,7 +25,7 @@ namespace Application.Features.Orders.Handlers.Queries
         {
             var order = await _orderRepository.GetOrderByIdWithDetail(request.Id);
 
-            if (order == null && order.UserId != request.UserName)
+            if (order == null || order.UserId != request.UserName)
             {
                 return null;
             }


### PR DESCRIPTION
## Summary
- fix conditional logic in `GetOrderQueryHandler`

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406f89bc14832ebaec74e0f18d4c50